### PR TITLE
Update nginx.conf

### DIFF
--- a/ngx-mruby/docker/conf/nginx.conf
+++ b/ngx-mruby/docker/conf/nginx.conf
@@ -44,7 +44,7 @@ http {
               userdata = Userdata.new
               userdata.proxy_dest
             ';
-            proxy_pass http://$backend;
+            proxy_pass http://$backend:3031;
         }
     }
 }

--- a/ngx-mruby/docker/conf/nginx.conf
+++ b/ngx-mruby/docker/conf/nginx.conf
@@ -39,7 +39,7 @@ http {
         }
 
         location / {
-            resolver 8.8.8.8 valid=2s;
+            resolver 127.0.0.11 valid=2s;
             mruby_set_code $backend '
               userdata = Userdata.new
               userdata.proxy_dest


### PR DESCRIPTION
docker networkのホスト名を解決したいので、resolverには `127.0.0.11` を指定。
$backednのportは3031で固定。
