### PR TITLE
Add stop signal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
   falcon:
     build:
       context: ./falcon
+    stop_signal: SIGQUIT
     expose:
       - "3031"
     networks:


### PR DESCRIPTION
`docker-compose down` を実行した時にタイムアウトで待たされるのでstop_signalを追加
